### PR TITLE
Add utility to detect container runtime

### DIFF
--- a/utilities/detect-container-runtime
+++ b/utilities/detect-container-runtime
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Setup Container Runtime
+
+if [[ -z "${CONTAINER_RUNTIME}" ]]; then
+ # Only need the check if the env var is not set
+ # Check if Podman is available
+  if podman ps &>/dev/null; then
+    CONTAINER_RUNTIME="podman"
+  # If Podman is not available, check for Docker
+  elif docker ps &>/dev/null; then
+    CONTAINER_RUNTIME="docker"
+    # If neither is available
+  else
+    CONTAINER_RUNTIME="none"
+    echo No container runtime found. Please install Podman or Docker.
+    exit 1
+  fi
+fi
+
+echo "CONTAINER_RUNTIME: $CONTAINER_RUNTIME"
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME}"

--- a/utilities/lab-build
+++ b/utilities/lab-build
@@ -14,22 +14,10 @@ echo "Removing old site..."
 rm -rf ./www/*
 
 echo "Building new site..."
-# Setup Container Runtime
-# Check if Podman is available
-if podman ps &>/dev/null; then
-  CONTAINER_RUNTIME="podman"
-  # If Podman is not available, check for Docker
-elif docker ps &>/dev/null; then
-  CONTAINER_RUNTIME="docker"
-  # If neither is available
-else
-  CONTAINER_RUNTIME="none"
-  echo No container runtime found. Please install Podman or Docker.
-  exit 1
-fi
 
-# Optionally, you can print the value for confirmation
-echo "CONTAINER_RUNTIME: $CONTAINER_RUNTIME"
+# Setup Container Runtime
+current_dir="$(dirname "$(realpath "$0")")"
+source $current_dir/detect-container-runtime
 
 volume_mount_flag=""
 os_name="$(uname -s)" # Detect the operating system, Linux needs `:z` macos does not

--- a/utilities/lab-serve
+++ b/utilities/lab-serve
@@ -2,8 +2,11 @@
 
 echo "Starting serve process..."
 # TODO: Add case statement to allow stopping, starting, and restarting
-# TODO: Add logic to detect both podman and docker, if both are installed, use podman as default "first found"
-CONTAINER_RUNTIME="podman"
+
+# Setup Container Runtime
+current_dir="$(dirname "$(realpath "$0")")"
+source $current_dir/detect-container-runtime
+
 # TODO: Move to RHEL image
 ${CONTAINER_RUNTIME} run -d --rm --name showroom-httpd -p 8443:80 -v "./www:/usr/local/apache2/htdocs/" docker.io/httpd:2.4
 echo "Serving lab content on http://localhost:8443/index.html"

--- a/utilities/lab-stop
+++ b/utilities/lab-stop
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
 echo "Stopping serve process..."
+# Setup Container Runtime
+current_dir="$(dirname "$(realpath "$0")")"
+source $current_dir/detect-container-runtime
+
 ${CONTAINER_RUNTIME} kill showroom-httpd
 echo "Stopped serve process."


### PR DESCRIPTION
A new utility script has been added to automatically detect the container runtime. Now, instead of hard coding the use of podman or docker, the script will check which container runtime is available and correspondingly set the 'CONTAINER_RUNTIME' environment variable. This simplifies and streamlines the process of running and managing containers.